### PR TITLE
Improve connection UX and add optional Sentry error reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.local.json
 *.local.config
 sentry.properties
+tracker.telemetry.local.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.4.0
+
+- Expanded the OptiTrack Stream component inputs for connection type, NatNet command/data ports, scale factor, Y-up transform, redraw throttle, debug logging, and optional telemetry enablement.
+- Added outputs for rigid body transforms, frame number, timestamp, latency, warnings, and telemetry status while preserving the original output order.
+- Added validation and clearer Grasshopper runtime messages for invalid IPs, invalid ports, missing NatNet DLLs, no-frame-after-connect cases, and telemetry configuration state.
+- Added optional Sentry error reporting through `ITelemetryService`, disabled by default and activated only when explicitly enabled and configured.
+- Added sanitized Sentry configuration support for `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, and local `tracker.telemetry.local.json`.
+- Updated setup, troubleshooting, telemetry, and Grasshopper component documentation.
+
 ## v1.3.0
 
 - Added SDK-independent OptiTrack core models and `IOptiTrackClient`.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ See [docs/setup.md](docs/setup.md) for more detail.
 
 ## Telemetry and Error Reporting
 
-Telemetry/error reporting is optional and disabled unless explicitly configured in a future integration. No Sentry DSN or project-specific telemetry setting is stored in source control.
+Telemetry/error reporting is optional and disabled unless explicitly enabled and configured. No Sentry DSN or project-specific telemetry setting is stored in source control.
 
-Future Sentry configuration, if added, should use environment variables, a local config file, or a user setting such as:
+Sentry configuration uses environment variables or a local config file such as:
 
 - `SENTRY_DSN`
 - `SENTRY_ENVIRONMENT`
@@ -75,7 +75,7 @@ Maintainers may use the Codex Sentry plugin for read-only issue review, but that
 
 ## Version
 
-Current modernization target: `v1.3.0`.
+Current modernization target: `v1.4.0`.
 
 ## Contributors
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ flowchart LR
 
 `TrackerComponent` consumes `IOptiTrackClient`, receives `OptiTrackFrame` instances, and converts them into Grasshopper outputs. Rhino geometry creation remains in the Grasshopper layer.
 
-`OptiTrack.Telemetry` defines a future reporting boundary. The active implementation is `NoOpTelemetryService`, so telemetry calls are local no-ops unless a later release explicitly configures a transport.
+`OptiTrack.Telemetry` defines the reporting boundary. The default implementation is `NoOpTelemetryService`; `SentryTelemetryService` is activated only when the Grasshopper component enables telemetry and a valid local Sentry configuration exists.
 
 ## Privacy
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,10 +10,10 @@ Tracker is a Rhino/Grasshopper plugin for OptiTrack Motive through NatNet. This 
 | Motive version | Compatible with NatNet SDK 4.0 | TBD | Confirm against the Motive version used in deployment. |
 | NatNet SDK version | 4.0 | TBD | `NatNetML.dll` is referenced from `lib/NatNet`. |
 | .NET target framework | .NET Framework 4.8, x64 build target | Build validation pending | Required by `src/Tracker/Tracker.csproj`; x64 matches Rhino 8 and bundled NatNet runtime files. |
-| Sentry SDK version | Not currently included | N/A | Future optional integration only. |
+| Sentry SDK version | 6.5.0 | Build validated | Optional and disabled unless configured. |
 
 ## Notes
 
 - Do not assume a Motive/NatNet upgrade is compatible without testing a live stream.
 - Keep the NatNet managed DLL and native DLL together with the built `Tracker.gha`.
-- If Sentry is added later, document the exact SDK version and default disabled behavior here.
+- Sentry remains optional and default-disabled.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -32,7 +32,7 @@ These models may contain motion-capture values for local Grasshopper output. The
 
 ## Telemetry
 
-Telemetry is represented by `ITelemetryService` and defaults to `NoOpTelemetryService`. New code may call the interface for sanitized operation boundaries, but must not add a real Sentry transport without a separate review.
+Telemetry is represented by `ITelemetryService` and defaults to `NoOpTelemetryService`. `SentryTelemetryService` is available for optional sanitized reporting, but it must remain disabled unless the component enables telemetry and a valid DSN is configured.
 
 Only send coarse operational fields to telemetry in future integrations. Never send marker coordinates, rigid body names, raw frame payloads, IP addresses, file paths, usernames, machine names, or Rhino document names.
 

--- a/docs/grasshopper-components.md
+++ b/docs/grasshopper-components.md
@@ -1,0 +1,49 @@
+# Grasshopper Components
+
+## OptiTrack Stream
+
+Category: `Tracker`  
+Subcategory: `OptiTrack`
+
+Connects to Motive over NatNet and streams OptiTrack data into Grasshopper.
+
+### Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `Connect` | `false` | Connect to the Motive NatNet stream. Previously named Activate; existing definitions should retain the same input position. |
+| `Reset` | `false` | Disconnect, reset cached frame data, and clear outputs. |
+| `Local IP` | `127.0.0.1` | Receiver network adapter IP address. |
+| `Server IP` | `127.0.0.1` | Motive server IP address. |
+| `Connection Type` | `Multicast` | `Multicast` or `Unicast`. Multicast matches the historical component behavior. |
+| `Command Port` | `1510` | NatNet server command port. |
+| `Data Port` | `1511` | NatNet server data port. |
+| `Scale Factor` | `1.0` | Additional scale applied to marker points and rigid body planes. |
+| `Y Up` | `false` | Applies the existing Y-up coordinate adjustment. |
+| `Redraw Throttle` | `4` | Processes every Nth NatNet frame. Use `1` for every frame. |
+| `Debug Logging` | `false` | Shows extra runtime remarks, including telemetry status. |
+| `Enable Telemetry` | `false` | Enables optional sanitized Sentry reporting only when configured. |
+
+### Outputs
+
+| Output | Description |
+| --- | --- |
+| `Status` | Connection and NatNet status messages. |
+| `Markers` | Marker points generated from the latest processed frame. |
+| `Labels` | Marker labels. |
+| `RB Name` | Rigid body names from Motive. These are local Grasshopper outputs and are never sent to telemetry. |
+| `BR Plane` | Rigid body planes. Name preserved for compatibility. |
+| `RB Transform` | Rigid body transforms derived from output planes. |
+| `Frame Number` | Latest processed NatNet frame number. |
+| `Timestamp` | Latest NatNet software timestamp in seconds. |
+| `Latency` | Approximate seconds since the NatNet host transmit timestamp. |
+| `Warnings` | Validation and runtime warnings. |
+| `Telemetry Status` | `disabled`, `active`, or `failed` state. |
+
+### Runtime Messages
+
+The component reports Grasshopper warnings/errors for invalid IP addresses, invalid ports, missing NatNet DLLs, unconfigured telemetry, and successful connection without frame data after several seconds.
+
+### Backwards Compatibility
+
+The first four inputs and first five outputs keep their original order. New inputs and outputs are appended so existing definitions should be migration-friendly.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,7 +37,20 @@ The project copies bundled NatNet files from `lib/NatNet` to the build output.
 
 1. Place **OptiTrack Stream** from the Tracker category.
 2. Set `Local IP` and `Server IP`.
-3. Set `Activate` to `true`.
-4. Use the component context menu to enable rigid-body output when required.
+3. Keep `Connection Type` as `Multicast` unless the Motive/network setup requires `Unicast`.
+4. Keep NatNet ports at `1510` command and `1511` data unless Motive is configured differently.
+5. Set `Connect` to `true`.
+6. Use the component context menu to enable rigid-body output when required.
+7. Inspect `Status`, `Warnings`, `Frame Number`, and `Telemetry Status`.
 
-The plugin should not require telemetry or Sentry configuration to run.
+The plugin does not require telemetry or Sentry configuration to run.
+
+## Optional Sentry Configuration
+
+Sentry is disabled by default. To enable it for sanitized error reporting:
+
+1. Set `Enable Telemetry` to `true` on the component.
+2. Provide a DSN through `SENTRY_DSN` or a local `tracker.telemetry.local.json` file next to the plugin output.
+3. Optionally set `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, and `SENTRY_TRACES_SAMPLE_RATE`.
+
+Do not commit local telemetry config files or DSNs.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and Error Reporting Policy
 
-Tracker must remain usable without telemetry. Error reporting is optional and disabled unless explicitly configured by the user or deployment owner.
+Tracker must remain usable without telemetry. Error reporting is optional and disabled unless explicitly enabled in Grasshopper and configured by the user or deployment owner.
 
 ## Defaults
 
@@ -12,7 +12,7 @@ Tracker must remain usable without telemetry. Error reporting is optional and di
 
 ## Future Sentry Configuration
 
-If Sentry support is added later, configuration should come from one of these sources:
+Tracker v1.4.0 includes optional Sentry support through the official Sentry .NET SDK. Configuration should come from one of these sources:
 
 - Environment variables
 - A local config file excluded from source control
@@ -22,12 +22,23 @@ Recognized placeholder settings:
 
 - `SENTRY_DSN` - optional DSN; telemetry remains disabled when absent or empty.
 - `SENTRY_ENVIRONMENT` - optional environment name such as `development`, `lab`, or `production`.
-- `SENTRY_RELEASE` - optional release identifier, for example `tracker@1.3.0`.
+- `SENTRY_RELEASE` - optional release identifier, for example `tracker@1.4.0`.
 - `SENTRY_TRACES_SAMPLE_RATE` - optional numeric sample rate for aggregate performance telemetry.
 
-## Current v1.3.0 Boundary
+A local config file named `tracker.telemetry.local.json` may be placed next to `Tracker.gha`. It is ignored by git and may contain:
 
-Tracker now includes an internal telemetry boundary:
+```json
+{
+  "SENTRY_DSN": "",
+  "SENTRY_ENVIRONMENT": "local",
+  "SENTRY_RELEASE": "tracker@1.4.0",
+  "SENTRY_TRACES_SAMPLE_RATE": "0"
+}
+```
+
+## Current v1.4.0 Boundary
+
+Tracker includes an internal telemetry boundary:
 
 - `ITelemetryService`
 - `NoOpTelemetryService`
@@ -36,7 +47,9 @@ Tracker now includes an internal telemetry boundary:
 - `TelemetryScope`
 - `TelemetrySanitizer`
 
-The Grasshopper component and NatNet adapter use this boundary for sanitized exception and operation hooks. The default implementation is no-op, so no data leaves the process.
+The Grasshopper component and NatNet adapter use this boundary for sanitized exception and operation hooks. The default implementation is no-op, so no data leaves the process. `SentryTelemetryService` is used only when the component telemetry input is enabled and a valid DSN is present.
+
+Sentry exceptions are reported with sanitized exception type/message data rather than raw capture payloads. Context tags and metrics pass through `TelemetrySanitizer` before reporting.
 
 ## Sentry Plugin Operations
 
@@ -81,4 +94,4 @@ Do not attach frame payloads or per-marker/per-rigid-body values.
 
 ## Disable Completely
 
-Telemetry must be disabled when `SENTRY_DSN` is missing, empty, or explicitly disabled by a local setting. Users should also be able to remove any local telemetry config file or clear related environment variables to disable reporting completely.
+Telemetry is disabled when `Enable Telemetry` is false, when `SENTRY_DSN` is missing or empty, or when local configuration is invalid. Users can remove `tracker.telemetry.local.json`, clear related environment variables, or set the component input to false to disable reporting completely.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,13 +21,19 @@ Confirm Motive is running, the tracking project is active, and NatNet streaming 
 
 `Local IP` should match the network adapter used by Rhino/Grasshopper. `Server IP` should match the Motive machine. The default `127.0.0.1` only works when Motive and Rhino are on the same machine and Motive is configured accordingly.
 
+Tracker now validates IP address format before connecting. A valid-looking IP can still be the wrong network adapter, so compare the component values with Motive and Windows network settings.
+
+## Wrong Command or Data Port
+
+The defaults are NatNet command port `1510` and data port `1511`. If Motive is configured differently, update the component inputs. The command and data ports must be valid TCP/UDP port numbers and should not be the same value.
+
 ## Firewall or Network Issues
 
 Windows Firewall or network security tools can block NatNet traffic. Allow Motive and Rhino through the firewall on the relevant private network. On managed networks, confirm multicast or UDP traffic is permitted.
 
 ## Multicast vs. Unicast
 
-Tracker currently uses multicast in code. If a network blocks multicast, the component may fail even when IP addresses are correct. Document the deployment network behavior before changing connection mode.
+Tracker supports multicast and unicast through the current NatNet adapter. Multicast remains the default for backwards compatibility. If a network blocks multicast, switch `Connection Type` to `Unicast` and confirm Motive is configured to support it.
 
 ## Grasshopper Plugin Does Not Load
 
@@ -42,6 +48,8 @@ Check these items:
 
 ## Telemetry Enabled or Disabled
 
-Telemetry/error reporting is disabled by default. In this version there is no runtime Sentry integration. If future builds add it, check for an explicit local setting, config file, or environment variable such as `SENTRY_DSN`. Removing that configuration must fully disable telemetry.
+Telemetry/error reporting is disabled by default. In v1.4.0 Sentry is available only when `Enable Telemetry` is `true` and `SENTRY_DSN` or `tracker.telemetry.local.json` is configured. Removing that configuration or setting `Enable Telemetry` to `false` disables reporting.
 
 Maintainers using the Codex Sentry plugin for read-only issue review should configure `SENTRY_AUTH_TOKEN` only in their local environment. That token is not required to run Tracker and must not be committed.
+
+If telemetry is enabled but not configured, the component reports telemetry as disabled and continues normally.

--- a/examples/01-connect-to-motive.md
+++ b/examples/01-connect-to-motive.md
@@ -1,0 +1,18 @@
+# Example: Connect to Motive
+
+1. Start Motive and confirm NatNet streaming is enabled.
+2. In Grasshopper, place `Tracker > OptiTrack > OptiTrack Stream`.
+3. For a local Motive instance, keep:
+
+   - `Local IP`: `127.0.0.1`
+   - `Server IP`: `127.0.0.1`
+   - `Connection Type`: `Multicast`
+   - `Command Port`: `1510`
+   - `Data Port`: `1511`
+   - `Redraw Throttle`: `4`
+
+4. Set `Connect` to `true`.
+5. Enable `Rigid Body` from the component context menu if rigid body planes/transforms are needed.
+6. Watch `Status`, `Warnings`, `Frame Number`, and `Latency`.
+
+Telemetry is not required. Leave `Enable Telemetry` as `false` unless a deployment owner has configured Sentry.

--- a/src/Tracker/OptiTrack/Core/OptiTrackConnectionInfo.cs
+++ b/src/Tracker/OptiTrack/Core/OptiTrackConnectionInfo.cs
@@ -16,6 +16,10 @@ namespace OptiTrack.Core {
 
 		public string NatNetVersion { get; set; } = string.Empty;
 
+		public int ServerCommandPort { get; set; }
+
+		public int ServerDataPort { get; set; }
+
 		public bool IsConnected {
 			get { return Status == OptiTrackConnectionStatus.Connected; }
 		}

--- a/src/Tracker/OptiTrack/Core/OptiTrackConnectionOptions.cs
+++ b/src/Tracker/OptiTrack/Core/OptiTrackConnectionOptions.cs
@@ -26,11 +26,5 @@ namespace OptiTrack.Core {
 		public bool IncludeForcePlates { get; set; }
 
 		public int FrameDivisor { get; set; } = 4;
-
-		public double ScaleFactor { get; set; } = 1.0;
-
-		public bool YUp { get; set; }
-
-		public bool DebugLogging { get; set; }
 	}
 }

--- a/src/Tracker/OptiTrack/Core/OptiTrackConnectionOptions.cs
+++ b/src/Tracker/OptiTrack/Core/OptiTrackConnectionOptions.cs
@@ -13,6 +13,10 @@ namespace OptiTrack.Core {
 
 		public OptiTrackConnectionType ConnectionType { get; set; } = OptiTrackConnectionType.Multicast;
 
+		public int ServerCommandPort { get; set; } = 1510;
+
+		public int ServerDataPort { get; set; } = 1511;
+
 		public bool IncludeMarkers { get; set; } = true;
 
 		public bool IncludeRigidBodies { get; set; }
@@ -22,5 +26,11 @@ namespace OptiTrack.Core {
 		public bool IncludeForcePlates { get; set; }
 
 		public int FrameDivisor { get; set; } = 4;
+
+		public double ScaleFactor { get; set; } = 1.0;
+
+		public bool YUp { get; set; }
+
+		public bool DebugLogging { get; set; }
 	}
 }

--- a/src/Tracker/OptiTrack/Core/OptiTrackModels.cs
+++ b/src/Tracker/OptiTrack/Core/OptiTrackModels.cs
@@ -56,6 +56,10 @@ namespace OptiTrack.Core {
 
 		public int FrameNumber { get; set; }
 
+		public double TimestampSeconds { get; set; }
+
+		public double LatencySeconds { get; set; }
+
 		public bool IsRecording { get; set; }
 
 		public bool AssetsChanged { get; set; }

--- a/src/Tracker/OptiTrack/NatNet/NatNetFrameConverter.cs
+++ b/src/Tracker/OptiTrack/NatNet/NatNetFrameConverter.cs
@@ -9,7 +9,7 @@ namespace OptiTrack.NatNet {
 
 	internal static class NatNetFrameConverter {
 
-		internal static OptiTrackFrame ConvertFrame( FrameOfMocapData data, IReadOnlyList<RigidBody> rigidBodyDescriptions, OptiTrackConnectionOptions options, IReadOnlyList<string> statusMessages ) {
+		internal static OptiTrackFrame ConvertFrame( FrameOfMocapData data, NatNetClientML client, IReadOnlyList<RigidBody> rigidBodyDescriptions, OptiTrackConnectionOptions options, IReadOnlyList<string> statusMessages ) {
 			List<OptiTrackMarker> markers = new List<OptiTrackMarker>();
 			List<OptiTrackRigidBody> rigidBodies = new List<OptiTrackRigidBody>();
 
@@ -54,6 +54,8 @@ namespace OptiTrack.NatNet {
 
 			return new OptiTrackFrame {
 				FrameNumber = data.iFrame,
+				TimestampSeconds = data.fTimestamp,
+				LatencySeconds = client.SecondsSinceHostTimestamp( data.TransmitTimestamp ),
 				IsRecording = data.bRecording,
 				AssetsChanged = data.bTrackingModelsChanged,
 				Markers = markers,

--- a/src/Tracker/OptiTrack/NatNet/NatNetOptiTrackClient.cs
+++ b/src/Tracker/OptiTrack/NatNet/NatNetOptiTrackClient.cs
@@ -75,7 +75,9 @@ namespace OptiTrack.NatNet {
 						NatNetClientML.ConnectParams connectParams = new NatNetClientML.ConnectParams {
 							ConnectionType = ToNatNetConnectionType( options.ConnectionType ),
 							ServerAddress = options.ServerAddress,
-							LocalAddress = options.LocalAddress
+							LocalAddress = options.LocalAddress,
+							ServerCommandPort = (ushort) options.ServerCommandPort,
+							ServerDataPort = (ushort) options.ServerDataPort
 						};
 
 						natNetClient.Connect( connectParams );
@@ -127,6 +129,8 @@ namespace OptiTrack.NatNet {
 				ConnectionInfo.HostApplication = serverDescription.HostApp;
 				ConnectionInfo.LocalAddress = options.LocalAddress;
 				ConnectionInfo.ServerAddress = options.ServerAddress;
+				ConnectionInfo.ServerCommandPort = options.ServerCommandPort;
+				ConnectionInfo.ServerDataPort = options.ServerDataPort;
 			} else {
 				statusMessages.Add( "Error: Failed to connect. Check the connection settings." );
 				statusMessages.Add( "Program terminated." );
@@ -189,7 +193,7 @@ namespace OptiTrack.NatNet {
 						FetchDataDescriptions();
 					}
 
-					frame = NatNetFrameConverter.ConvertFrame( data, rigidBodies, options, new List<string>( statusMessages ) );
+					frame = NatNetFrameConverter.ConvertFrame( data, client, rigidBodies, options, new List<string>( statusMessages ) );
 				}
 
 				EventHandler<OptiTrackFrameEventArgs> handler = FrameReceived;

--- a/src/Tracker/OptiTrack/Telemetry/ITelemetryService.cs
+++ b/src/Tracker/OptiTrack/Telemetry/ITelemetryService.cs
@@ -4,6 +4,8 @@ namespace OptiTrack.Telemetry {
 
 	public interface ITelemetryService {
 
+		string Status { get; }
+
 		void CaptureException( Exception exception, TelemetryContext context );
 
 		void CaptureMessage( string message, TelemetrySeverity severity, TelemetryContext context );

--- a/src/Tracker/OptiTrack/Telemetry/NoOpTelemetryService.cs
+++ b/src/Tracker/OptiTrack/Telemetry/NoOpTelemetryService.cs
@@ -4,6 +4,16 @@ namespace OptiTrack.Telemetry {
 
 	public sealed class NoOpTelemetryService : ITelemetryService {
 
+		public NoOpTelemetryService()
+			: this( "disabled" ) {
+		}
+
+		public NoOpTelemetryService( string status ) {
+			Status = status;
+		}
+
+		public string Status { get; private set; }
+
 		public void CaptureException( Exception exception, TelemetryContext context ) {
 		}
 

--- a/src/Tracker/OptiTrack/Telemetry/SentryTelemetryOptions.cs
+++ b/src/Tracker/OptiTrack/Telemetry/SentryTelemetryOptions.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Globalization;
+using System.IO;
+
+using Newtonsoft.Json.Linq;
+
+namespace OptiTrack.Telemetry {
+
+	public sealed class SentryTelemetryOptions {
+
+		public string Dsn { get; set; } = string.Empty;
+
+		public string Environment { get; set; } = string.Empty;
+
+		public string Release { get; set; } = "tracker@1.4.0";
+
+		public double? TracesSampleRate { get; set; }
+
+		public static SentryTelemetryOptions Load() {
+			SentryTelemetryOptions options = new SentryTelemetryOptions {
+				Dsn = System.Environment.GetEnvironmentVariable( "SENTRY_DSN" ) ?? string.Empty,
+				Environment = System.Environment.GetEnvironmentVariable( "SENTRY_ENVIRONMENT" ) ?? string.Empty,
+				Release = System.Environment.GetEnvironmentVariable( "SENTRY_RELEASE" ) ?? "tracker@1.4.0"
+			};
+
+			string tracesSampleRate = System.Environment.GetEnvironmentVariable( "SENTRY_TRACES_SAMPLE_RATE" );
+			if ( double.TryParse( tracesSampleRate, NumberStyles.Float, CultureInfo.InvariantCulture, out double sampleRate ) ) {
+				options.TracesSampleRate = sampleRate;
+			}
+
+			LoadLocalFile( options );
+			return options;
+		}
+
+		private static void LoadLocalFile( SentryTelemetryOptions options ) {
+			string path = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, "tracker.telemetry.local.json" );
+			if ( !File.Exists( path ) ) {
+				return;
+			}
+
+			JObject json = JObject.Parse( File.ReadAllText( path ) );
+			options.Dsn = (string) json[ "SENTRY_DSN" ] ?? options.Dsn;
+			options.Environment = (string) json[ "SENTRY_ENVIRONMENT" ] ?? options.Environment;
+			options.Release = (string) json[ "SENTRY_RELEASE" ] ?? options.Release;
+
+			JToken tracesSampleRate = json[ "SENTRY_TRACES_SAMPLE_RATE" ];
+			if ( tracesSampleRate != null && double.TryParse( tracesSampleRate.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out double sampleRate ) ) {
+				options.TracesSampleRate = sampleRate;
+			}
+		}
+
+		public bool HasValidDsn() {
+			return !string.IsNullOrWhiteSpace( Dsn ) && Uri.TryCreate( Dsn, UriKind.Absolute, out _ );
+		}
+	}
+}

--- a/src/Tracker/OptiTrack/Telemetry/SentryTelemetryOptions.cs
+++ b/src/Tracker/OptiTrack/Telemetry/SentryTelemetryOptions.cs
@@ -33,7 +33,16 @@ namespace OptiTrack.Telemetry {
 		}
 
 		private static void LoadLocalFile( SentryTelemetryOptions options ) {
-			string path = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, "tracker.telemetry.local.json" );
+			string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+			string assemblyLocation = typeof( SentryTelemetryOptions ).Assembly.Location;
+			if ( !string.IsNullOrWhiteSpace( assemblyLocation ) ) {
+				string assemblyDirectory = Path.GetDirectoryName( assemblyLocation );
+				if ( !string.IsNullOrWhiteSpace( assemblyDirectory ) ) {
+					baseDirectory = assemblyDirectory;
+				}
+			}
+
+			string path = Path.Combine( baseDirectory, "tracker.telemetry.local.json" );
 			if ( !File.Exists( path ) ) {
 				return;
 			}

--- a/src/Tracker/OptiTrack/Telemetry/SentryTelemetryService.cs
+++ b/src/Tracker/OptiTrack/Telemetry/SentryTelemetryService.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Reflection;
+
+using Sentry;
+
+namespace OptiTrack.Telemetry {
+
+	public sealed class SentryTelemetryService : ITelemetryService, IDisposable {
+		private readonly IDisposable sentry;
+		private bool disposed;
+
+		private SentryTelemetryService( IDisposable sentry, string status ) {
+			this.sentry = sentry;
+			Status = status;
+		}
+
+		public string Status { get; private set; }
+
+		public static ITelemetryService Create( bool enabled ) {
+			if ( !enabled ) {
+				return new NoOpTelemetryService( "disabled" );
+			}
+
+			try {
+				SentryTelemetryOptions configuration = SentryTelemetryOptions.Load();
+				if ( !configuration.HasValidDsn() ) {
+					return new NoOpTelemetryService( "disabled: Sentry DSN missing or invalid" );
+				}
+
+				IDisposable sentry = SentrySdk.Init( options => {
+					options.Dsn = configuration.Dsn;
+					options.Environment = string.IsNullOrWhiteSpace( configuration.Environment ) ? "local" : TelemetrySanitizer.SanitizeValue( configuration.Environment );
+					options.Release = TelemetrySanitizer.SanitizeValue( configuration.Release );
+					options.SendDefaultPii = false;
+					options.AttachStacktrace = true;
+					options.TracesSampleRate = ClampSampleRate( configuration.TracesSampleRate );
+					options.SetBeforeSend( evt => {
+						evt.ServerName = null;
+						evt.Request = null;
+						return evt;
+					} );
+				} );
+
+				SentrySdk.SetTag( "plugin_version", GetPluginVersion() );
+				SentrySdk.SetTag( "adapter_name", "NatNet" );
+				SentrySdk.SetTag( "rhino_version", GetRhinoVersion() );
+
+				return new SentryTelemetryService( sentry, "active" );
+			} catch {
+				return new NoOpTelemetryService( "failed: Sentry configuration could not be initialized" );
+			}
+		}
+
+		public void CaptureException( Exception exception, TelemetryContext context ) {
+			if ( exception == null ) {
+				return;
+			}
+
+			try {
+				Exception sanitizedException = new Exception( TelemetrySanitizer.SanitizeValue( exception.GetType().Name + ": " + exception.Message ) );
+				SentrySdk.CaptureException( sanitizedException, scope => {
+					ApplyContext( scope, context );
+					scope.SetTag( "exception_type", TelemetrySanitizer.SanitizeValue( exception.GetType().Name ) );
+				} );
+			} catch {
+				Status = "failed: Sentry capture failed";
+			}
+		}
+
+		public void CaptureMessage( string message, TelemetrySeverity severity, TelemetryContext context ) {
+			try {
+				SentrySdk.CaptureMessage( TelemetrySanitizer.SanitizeValue( message ), scope => ApplyContext( scope, context ), ToSentryLevel( severity ) );
+			} catch {
+				Status = "failed: Sentry capture failed";
+			}
+		}
+
+		public TelemetryScope StartSpan( string operationName, TelemetryContext context ) {
+			return new TelemetryScope( this, operationName, context );
+		}
+
+		public void Dispose() {
+			if ( disposed ) {
+				return;
+			}
+
+			disposed = true;
+			sentry.Dispose();
+		}
+
+		private static void ApplyContext( Scope scope, TelemetryContext context ) {
+			if ( context == null ) {
+				return;
+			}
+
+			foreach ( var tag in context.Tags ) {
+				if ( TelemetrySanitizer.IsSensitiveKey( tag.Key ) ) {
+					continue;
+				}
+
+				scope.SetTag( TelemetrySanitizer.SanitizeKey( tag.Key ), TelemetrySanitizer.SanitizeValue( tag.Value ) );
+			}
+
+			foreach ( var metric in context.Metrics ) {
+				if ( TelemetrySanitizer.IsSensitiveKey( metric.Key ) ) {
+					continue;
+				}
+
+				scope.SetExtra( TelemetrySanitizer.SanitizeKey( metric.Key ), metric.Value );
+			}
+		}
+
+		private static double? ClampSampleRate( double? sampleRate ) {
+			if ( !sampleRate.HasValue ) {
+				return null;
+			}
+
+			return Math.Max( 0.0, Math.Min( 1.0, sampleRate.Value ) );
+		}
+
+		private static SentryLevel ToSentryLevel( TelemetrySeverity severity ) {
+			switch ( severity ) {
+				case TelemetrySeverity.Debug:
+				return SentryLevel.Debug;
+				case TelemetrySeverity.Warning:
+				return SentryLevel.Warning;
+				case TelemetrySeverity.Error:
+				return SentryLevel.Error;
+				case TelemetrySeverity.Fatal:
+				return SentryLevel.Fatal;
+				default:
+				return SentryLevel.Info;
+			}
+		}
+
+		private static string GetPluginVersion() {
+			return typeof( SentryTelemetryService ).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+		}
+
+		private static string GetRhinoVersion() {
+			try {
+				return Rhino.RhinoApp.Version.ToString();
+			} catch {
+				return "unknown";
+			}
+		}
+	}
+}

--- a/src/Tracker/Properties/AssemblyInfo.cs
+++ b/src/Tracker/Properties/AssemblyInfo.cs
@@ -27,6 +27,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers by
 // using the '*' as shown below: [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.3.0.0" )]
-[assembly: AssemblyFileVersion( "1.3.0.0" )]
-[assembly: AssemblyInformationalVersion( "1.3.0" )]
+[assembly: AssemblyVersion( "1.4.0.0" )]
+[assembly: AssemblyFileVersion( "1.4.0.0" )]
+[assembly: AssemblyInformationalVersion( "1.4.0" )]

--- a/src/Tracker/Tracker.csproj
+++ b/src/Tracker/Tracker.csproj
@@ -73,6 +73,8 @@
     <Compile Include="OptiTrack\NatNet\NatNetOptiTrackClient.cs" />
     <Compile Include="OptiTrack\Telemetry\ITelemetryService.cs" />
     <Compile Include="OptiTrack\Telemetry\NoOpTelemetryService.cs" />
+    <Compile Include="OptiTrack\Telemetry\SentryTelemetryOptions.cs" />
+    <Compile Include="OptiTrack\Telemetry\SentryTelemetryService.cs" />
     <Compile Include="OptiTrack\Telemetry\TelemetryContext.cs" />
     <Compile Include="OptiTrack\Telemetry\TelemetryEvent.cs" />
     <Compile Include="OptiTrack\Telemetry\TelemetrySanitizer.cs" />
@@ -106,9 +108,12 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
+    <PackageReference Include="Sentry" Version="6.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
     </PackageReference>
+    <PackageReference Include="System.Reflection.Metadata" Version="7.0.0" />
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>
     </PackageReference>

--- a/src/Tracker/TrackerComponent.cs
+++ b/src/Tracker/TrackerComponent.cs
@@ -433,11 +433,13 @@ namespace Tracker {
 				return;
 			}
 
-			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > NoFrameWarningThresholdSeconds && !noFrameWarningReported ) {
+			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > NoFrameWarningThresholdSeconds ) {
 				string warning = "Connected, but no NatNet frame has been received. Check Motive broadcasting, firewall, IP addresses, ports, and multicast/unicast settings.";
 				warnings.Add( warning );
-				AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );
-				noFrameWarningReported = true;
+				if ( !noFrameWarningReported ) {
+					AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );
+					noFrameWarningReported = true;
+				}
 			}
 		}
 

--- a/src/Tracker/TrackerComponent.cs
+++ b/src/Tracker/TrackerComponent.cs
@@ -19,6 +19,9 @@ namespace Tracker {
 	/// The main tracker component.
 	/// </summary>
 	public class TrackerComponent : GH_Component {
+		private const int YUpInputIndex = 8;
+		private const double NoFrameWarningThresholdSeconds = 5.0;
+
 		private static ITelemetryService telemetry = new NoOpTelemetryService();
 		private static IOptiTrackClient optiTrackClient = CreateClient( telemetry );
 		private static OptiTrackFrame currentFrame;
@@ -116,7 +119,7 @@ namespace Tracker {
 			DA.GetData( 11, ref enableTelemetry );
 
 			warnings.Clear();
-			if ( Params.Input[ 8 ].SourceCount > 0 ) {
+			if ( Params.Input[ YUpInputIndex ].SourceCount > 0 ) {
 				yUp = yUpInput;
 			}
 			ConfigureTelemetry( enableTelemetry );
@@ -431,7 +434,7 @@ namespace Tracker {
 				return;
 			}
 
-			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > 5 && !noFrameWarningReported ) {
+			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > NoFrameWarningThresholdSeconds && !noFrameWarningReported ) {
 				string warning = "Connected, but no NatNet frame has been received. Check Motive broadcasting, firewall, IP addresses, ports, and multicast/unicast settings.";
 				warnings.Add( warning );
 				AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );

--- a/src/Tracker/TrackerComponent.cs
+++ b/src/Tracker/TrackerComponent.cs
@@ -195,7 +195,7 @@ namespace Tracker {
 			}
 
 			telemetry = SentryTelemetryService.Create( enableTelemetry );
-			bool wasConnected = connectionConfirmed || (optiTrackClient != null && optiTrackClient.IsConnected);
+			bool wasConnected = optiTrackClient != null && optiTrackClient.IsConnected;
 			if ( wasConnected ) {
 				DisconnectClient();
 				Log.Add( "Telemetry setting changed. Reconnecting to apply updated telemetry." );
@@ -430,7 +430,6 @@ namespace Tracker {
 
 		private void ReportNoFrameWarning() {
 			if ( currentFrame != null || connectionStartedUtc == DateTime.MinValue ) {
-				noFrameWarningReported = false;
 				return;
 			}
 

--- a/src/Tracker/TrackerComponent.cs
+++ b/src/Tracker/TrackerComponent.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -17,11 +19,14 @@ namespace Tracker {
 	/// The main tracker component.
 	/// </summary>
 	public class TrackerComponent : GH_Component {
-		private static readonly ITelemetryService Telemetry = new NoOpTelemetryService();
-		private static IOptiTrackClient optiTrackClient = CreateClient();
+		private static ITelemetryService telemetry = new NoOpTelemetryService();
+		private static IOptiTrackClient optiTrackClient = CreateClient( telemetry );
 		private static OptiTrackFrame currentFrame;
+		private static DateTime connectionStartedUtc = DateTime.MinValue;
+		private static DateTime lastFrameUtc = DateTime.MinValue;
 		private static bool handlersAttached;
 		private static bool connectionConfirmed;
+		private static bool telemetryEnabled;
 		private static int counter;
 
 		private static bool RigidBody;
@@ -34,24 +39,34 @@ namespace Tracker {
 		protected static List<string> mLabels = new List<string>();
 		private static readonly List<string> rBodyNames = new List<string>();
 		private static readonly List<Plane> rBodyPlanes = new List<Plane>();
+		private static readonly List<Transform> rBodyTransforms = new List<Transform>();
+		private static readonly List<string> warnings = new List<string>();
 
 		public TrackerComponent()
 			: base( "OptiTrack Stream",
 						"OptiTrack Stream",
-						"Receive streaming data from a running Motive broadcast.",
+						"Connect to Motive over NatNet and stream OptiTrack data into Grasshopper.",
 						"Tracker",
 						"OptiTrack" ) {
 		}
 
-		private static IOptiTrackClient CreateClient() {
-			return new NatNetOptiTrackClient( Telemetry );
+		private static IOptiTrackClient CreateClient( ITelemetryService telemetryService ) {
+			return new NatNetOptiTrackClient( telemetryService );
 		}
 
 		protected override void RegisterInputParams( GH_InputParamManager pManager ) {
-			pManager.AddBooleanParameter( "Activate", "Activate", "Activate the streaming module.", GH_ParamAccess.item, false );
-			pManager.AddBooleanParameter( "Reset", "Reset", "Reset the streaming module.", GH_ParamAccess.item, false );
-			pManager.AddTextParameter( "Local IP", "Local IP", "IP address for the receiver.", GH_ParamAccess.item, "127.0.0.1" );
-			pManager.AddTextParameter( "Server IP", "Server IP", "IP address for the server.", GH_ParamAccess.item, "127.0.0.1" );
+			pManager.AddBooleanParameter( "Connect", "Connect", "Connect to the Motive NatNet stream.", GH_ParamAccess.item, false );
+			pManager.AddBooleanParameter( "Reset", "Reset", "Reset the streaming client and clear cached frame data.", GH_ParamAccess.item, false );
+			pManager.AddTextParameter( "Local IP", "Local IP", "IP address for the receiver network adapter.", GH_ParamAccess.item, "127.0.0.1" );
+			pManager.AddTextParameter( "Server IP", "Server IP", "IP address for the Motive server.", GH_ParamAccess.item, "127.0.0.1" );
+			pManager.AddTextParameter( "Connection Type", "Type", "NatNet connection type: Multicast or Unicast.", GH_ParamAccess.item, "Multicast" );
+			pManager.AddIntegerParameter( "Command Port", "Cmd Port", "NatNet server command port.", GH_ParamAccess.item, 1510 );
+			pManager.AddIntegerParameter( "Data Port", "Data Port", "NatNet server data port.", GH_ParamAccess.item, 1511 );
+			pManager.AddNumberParameter( "Scale Factor", "Scale", "Additional scale factor applied to rigid body planes.", GH_ParamAccess.item, 1.0 );
+			pManager.AddBooleanParameter( "Y Up", "Y Up", "Apply the existing Y-up coordinate adjustment.", GH_ParamAccess.item, false );
+			pManager.AddIntegerParameter( "Redraw Throttle", "Throttle", "Process every Nth NatNet frame. Use 1 for every frame.", GH_ParamAccess.item, 4 );
+			pManager.AddBooleanParameter( "Debug Logging", "Debug", "Show additional component runtime remarks.", GH_ParamAccess.item, false );
+			pManager.AddBooleanParameter( "Enable Telemetry", "Telemetry", "Enable optional sanitized Sentry error reporting when configured.", GH_ParamAccess.item, false );
 		}
 
 		protected override void RegisterOutputParams( GH_OutputParamManager pManager ) {
@@ -60,15 +75,29 @@ namespace Tracker {
 			pManager.AddTextParameter( "Labels", "Labels", "Marker labels.", GH_ParamAccess.list );
 			pManager.AddTextParameter( "RB Name", "RB Name", "List of Rigid Body name data.", GH_ParamAccess.list );
 			pManager.AddPlaneParameter( "BR Plane", "BR Plane", "List of planes assosieated with the Ridgid Bodys", GH_ParamAccess.list );
+			pManager.AddTransformParameter( "RB Transform", "RB XForm", "Rigid body transforms derived from output planes.", GH_ParamAccess.list );
+			pManager.AddIntegerParameter( "Frame Number", "Frame", "Latest processed NatNet frame number.", GH_ParamAccess.item );
+			pManager.AddNumberParameter( "Timestamp", "Time", "Latest processed NatNet software timestamp in seconds.", GH_ParamAccess.item );
+			pManager.AddNumberParameter( "Latency", "Latency", "Approximate seconds since NatNet host transmit timestamp.", GH_ParamAccess.item );
+			pManager.AddTextParameter( "Warnings", "Warnings", "Validation and runtime warnings.", GH_ParamAccess.list );
+			pManager.AddTextParameter( "Telemetry Status", "Telemetry", "Telemetry status: disabled, active, or failed.", GH_ParamAccess.item );
 		}
 
 		protected override void SolveInstance( IGH_DataAccess DA ) {
-			bool activate = false;
+			bool connect = false;
 			bool reset = false;
 			string localIP = "127.0.0.1";
 			string serverIP = "127.0.0.1";
+			string connectionTypeText = "Multicast";
+			int commandPort = 1510;
+			int dataPort = 1511;
+			double scaleFactor = 1.0;
+			bool yUpInput = yUp;
+			int redrawThrottle = 4;
+			bool debugLogging = false;
+			bool enableTelemetry = false;
 
-			if ( !DA.GetData( 0, ref activate ) )
+			if ( !DA.GetData( 0, ref connect ) )
 				return;
 			if ( !DA.GetData( 1, ref reset ) )
 				return;
@@ -77,67 +106,151 @@ namespace Tracker {
 			if ( !DA.GetData( 3, ref serverIP ) )
 				return;
 
+			DA.GetData( 4, ref connectionTypeText );
+			DA.GetData( 5, ref commandPort );
+			DA.GetData( 6, ref dataPort );
+			DA.GetData( 7, ref scaleFactor );
+			DA.GetData( 8, ref yUpInput );
+			DA.GetData( 9, ref redrawThrottle );
+			DA.GetData( 10, ref debugLogging );
+			DA.GetData( 11, ref enableTelemetry );
+
+			warnings.Clear();
+			yUp = yUpInput;
+			ConfigureTelemetry( enableTelemetry );
+
+			OptiTrackConnectionType connectionType = ParseConnectionType( connectionTypeText );
+			bool valid = ValidateConfiguration( localIP, serverIP, commandPort, dataPort, scaleFactor, redrawThrottle, connectionTypeText );
+			foreach ( string warning in warnings ) {
+				AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );
+			}
+
+			if ( !valid ) {
+				AddRuntimeMessage( GH_RuntimeMessageLevel.Error, "Tracker configuration is invalid. Fix warnings before connecting." );
+				telemetry.CaptureMessage( "invalid_tracker_configuration", TelemetrySeverity.Warning, new TelemetryContext().SetTag( "operation", "component_validation" ) );
+				SetOutputs( DA );
+				return;
+			}
+
 			if ( reset ) {
 				ClearFrameState();
 				DisconnectClient();
 				counter = 0;
+				AddRuntimeMessage( GH_RuntimeMessageLevel.Remark, "Tracker client reset." );
 			}
 
-			if ( activate && counter == 0 ) {
-				ConnectClient( localIP, serverIP );
+			if ( connect && counter == 0 ) {
+				ConnectClient( localIP, serverIP, connectionType, commandPort, dataPort, scaleFactor, redrawThrottle, debugLogging );
 				counter++;
-			} else if ( activate && connectionConfirmed ) {
-				ProcessFrameData( currentFrame );
+			} else if ( connect && connectionConfirmed ) {
+				ProcessFrameData( currentFrame, scaleFactor );
+				ReportNoFrameWarning();
 				counter++;
-			} else if ( !activate ) {
+			} else if ( !connect ) {
 				DisconnectClient();
 				ClearFrameState();
-				Log.Add( "Service stopped. Activate module to begin streaming." );
+				Log.Add( "Service stopped. Set Connect to true to begin streaming." );
 			}
 
+			if ( debugLogging ) {
+				AddRuntimeMessage( GH_RuntimeMessageLevel.Remark, "Telemetry: " + telemetry.Status );
+			}
+
+			SetOutputs( DA );
+			ExpireSolution( true );
+		}
+
+		private void SetOutputs( IGH_DataAccess DA ) {
 			try {
 				DA.SetDataList( "Status", Log );
 				DA.SetDataList( "Markers", mPoints );
 				DA.SetDataList( "Labels", mLabels );
 				DA.SetDataList( "RB Name", rBodyNames );
 				DA.SetDataList( "BR Plane", rBodyPlanes );
+				DA.SetDataList( "RB Transform", rBodyTransforms );
+				DA.SetData( "Frame Number", currentFrame == null ? 0 : currentFrame.FrameNumber );
+				DA.SetData( "Timestamp", currentFrame == null ? 0.0 : currentFrame.TimestampSeconds );
+				DA.SetData( "Latency", currentFrame == null ? 0.0 : currentFrame.LatencySeconds );
+				DA.SetDataList( "Warnings", warnings );
+				DA.SetData( "Telemetry Status", telemetry.Status );
 			} catch ( Exception exception ) {
-				Telemetry.CaptureException( exception, new TelemetryContext().SetTag( "operation", "grasshopper_set_output" ) );
+				telemetry.CaptureException( exception, new TelemetryContext().SetTag( "operation", "grasshopper_set_output" ) );
+				AddRuntimeMessage( GH_RuntimeMessageLevel.Error, "Failed to set Tracker outputs." );
 			}
-
-			ExpireSolution( true );
 		}
 
-		private static void ConnectClient( string localIP, string serverIP ) {
+		private static void ConfigureTelemetry( bool enableTelemetry ) {
+			if ( telemetryEnabled == enableTelemetry ) {
+				return;
+			}
+
+			telemetryEnabled = enableTelemetry;
+			IDisposable disposableTelemetry = telemetry as IDisposable;
+			if ( disposableTelemetry != null ) {
+				disposableTelemetry.Dispose();
+			}
+
+			telemetry = SentryTelemetryService.Create( enableTelemetry );
+			if ( !connectionConfirmed ) {
+				ResetClient();
+			}
+		}
+
+		private static void ResetClient() {
+			if ( optiTrackClient != null && handlersAttached ) {
+				optiTrackClient.FrameReceived -= OnFrameReceived;
+				optiTrackClient.ConnectionChanged -= OnConnectionChanged;
+			}
+
+			optiTrackClient = CreateClient( telemetry );
+			handlersAttached = false;
+		}
+
+		private static void ConnectClient( string localIP, string serverIP, OptiTrackConnectionType connectionType, int commandPort, int dataPort, double scaleFactor, int redrawThrottle, bool debugLogging ) {
 			EnsureClientHandlers();
 			Log.Clear();
 			Log.Add( "NatNet managed client application starting..." );
 			Log.Add( "Local IP set." );
 			Log.Add( "Server IP set." );
-			Log.Add( "Attempting connection to server..." );
+			Log.Add( "Attempting connection to Motive NatNet server..." );
+			connectionStartedUtc = DateTime.UtcNow;
+			lastFrameUtc = DateTime.MinValue;
 
 			OptiTrackConnectionOptions options = new OptiTrackConnectionOptions {
 				LocalAddress = localIP,
 				ServerAddress = serverIP,
-				ConnectionType = OptiTrackConnectionType.Multicast,
+				ConnectionType = connectionType,
+				ServerCommandPort = commandPort,
+				ServerDataPort = dataPort,
 				IncludeMarkers = true,
 				IncludeRigidBodies = RigidBody,
 				IncludeSkeletons = Skeleton,
 				IncludeForcePlates = ForcePlate,
-				FrameDivisor = 4
+				FrameDivisor = redrawThrottle,
+				ScaleFactor = scaleFactor,
+				YUp = yUp,
+				DebugLogging = debugLogging
 			};
 
 			try {
 				optiTrackClient.ConnectAsync( options, CancellationToken.None ).GetAwaiter().GetResult();
 				connectionConfirmed = optiTrackClient.IsConnected;
 				if ( connectionConfirmed ) {
-					Log.Add( "Fetching the Frame Data." );
-					Log.Add( "Success: Data Port Connected." );
+					Log.Add( "Fetching frame data." );
+					Log.Add( "Success: Data port connected." );
 				}
+			} catch ( FileNotFoundException exception ) {
+				connectionConfirmed = false;
+				Log.Add( "Error: NatNet dependency is missing. Check NatNetML.dll and NatNetLib.dll next to Tracker.gha." );
+				telemetry.CaptureException( exception, new TelemetryContext().SetTag( "operation", "component_connect_missing_dependency" ) );
+			} catch ( BadImageFormatException exception ) {
+				connectionConfirmed = false;
+				Log.Add( "Error: NatNet dependency architecture mismatch. Use x64 NatNet DLLs with Rhino 8." );
+				telemetry.CaptureException( exception, new TelemetryContext().SetTag( "operation", "component_connect_bad_image" ) );
 			} catch ( Exception exception ) {
 				connectionConfirmed = false;
-				Log.Add( "Error: Failed to connect. Check the connection settings." );
-				Telemetry.CaptureException( exception, new TelemetryContext().SetTag( "operation", "component_connect" ) );
+				Log.Add( "Error: Failed to connect. Check Motive broadcast settings, IP addresses, ports, firewall, and connection type." );
+				telemetry.CaptureException( exception, new TelemetryContext().SetTag( "operation", "component_connect" ) );
 			}
 		}
 
@@ -163,6 +276,7 @@ namespace Tracker {
 
 		private static void OnFrameReceived( object sender, OptiTrackFrameEventArgs e ) {
 			currentFrame = e.Frame;
+			lastFrameUtc = DateTime.UtcNow;
 		}
 
 		private static void OnConnectionChanged( object sender, OptiTrackConnectionEventArgs e ) {
@@ -178,9 +292,11 @@ namespace Tracker {
 			mLabels.Clear();
 			rBodyNames.Clear();
 			rBodyPlanes.Clear();
+			rBodyTransforms.Clear();
+			warnings.Clear();
 		}
 
-		private static void ProcessFrameData( OptiTrackFrame frame ) {
+		private void ProcessFrameData( OptiTrackFrame frame, double scaleFactor ) {
 			if ( frame == null ) {
 				return;
 			}
@@ -189,6 +305,7 @@ namespace Tracker {
 			mLabels.Clear();
 			rBodyNames.Clear();
 			rBodyPlanes.Clear();
+			rBodyTransforms.Clear();
 
 			Log.Clear();
 			foreach ( string message in frame.StatusMessages ) {
@@ -197,6 +314,7 @@ namespace Tracker {
 
 			foreach ( OptiTrackMarker marker in frame.Markers ) {
 				mLabels.Add( marker.Label );
+				mPoints.Add( new Point3d( marker.X * scaleFactor, marker.Y * scaleFactor, marker.Z * scaleFactor ) );
 			}
 
 			if ( RigidBody ) {
@@ -206,12 +324,14 @@ namespace Tracker {
 					}
 
 					rBodyNames.Add( rigidBody.Name );
-					rBodyPlanes.Add( CreateRigidBodyPlane( rigidBody ) );
+					Plane plane = CreateRigidBodyPlane( rigidBody, scaleFactor );
+					rBodyPlanes.Add( plane );
+					rBodyTransforms.Add( Transform.PlaneToPlane( Plane.WorldXY, plane ) );
 				}
 			}
 		}
 
-		private static Plane CreateRigidBodyPlane( OptiTrackRigidBody rigidBody ) {
+		private static Plane CreateRigidBodyPlane( OptiTrackRigidBody rigidBody, double scaleFactor ) {
 			Quaternion rbQuat = new Quaternion( rigidBody.Qw, rigidBody.Qx, rigidBody.Qy, rigidBody.Qz );
 			rbQuat.GetRotation( out Plane rbPlane );
 			rbPlane.Origin = new Point3d( rigidBody.X, rigidBody.Y, rigidBody.Z );
@@ -219,6 +339,10 @@ namespace Tracker {
 			var doc = Rhino.RhinoDoc.ActiveDoc;
 			if ( doc != null && doc.ModelUnitSystem == Rhino.UnitSystem.Millimeters ) {
 				rbPlane.Transform( Transform.Scale( new Point3d( 0, 0, 0 ), 1000 ) );
+			}
+
+			if ( Math.Abs( scaleFactor - 1.0 ) > 0.000001 ) {
+				rbPlane.Transform( Transform.Scale( new Point3d( 0, 0, 0 ), scaleFactor ) );
 			}
 
 			Transform xformYup = new Transform();
@@ -237,6 +361,96 @@ namespace Tracker {
 
 			rbPlane.Transform( xRotate );
 			return rbPlane;
+		}
+
+		private bool ValidateConfiguration( string localIP, string serverIP, int commandPort, int dataPort, double scaleFactor, int redrawThrottle, string connectionTypeText ) {
+			bool valid = true;
+
+			if ( !IPAddress.TryParse( localIP, out _ ) ) {
+				warnings.Add( "Local IP address is invalid." );
+				valid = false;
+			}
+
+			if ( !IPAddress.TryParse( serverIP, out _ ) ) {
+				warnings.Add( "Server IP address is invalid." );
+				valid = false;
+			}
+
+			if ( !IsValidPort( commandPort ) ) {
+				warnings.Add( "Command port must be between 1 and 65535." );
+				valid = false;
+			}
+
+			if ( !IsValidPort( dataPort ) ) {
+				warnings.Add( "Data port must be between 1 and 65535." );
+				valid = false;
+			}
+
+			if ( commandPort == dataPort ) {
+				warnings.Add( "Command port and data port should be different." );
+				valid = false;
+			}
+
+			if ( scaleFactor <= 0 ) {
+				warnings.Add( "Scale factor must be greater than zero." );
+				valid = false;
+			}
+
+			if ( redrawThrottle < 1 ) {
+				warnings.Add( "Redraw throttle must be 1 or greater." );
+				valid = false;
+			}
+
+			if ( ParseConnectionType( connectionTypeText ) == OptiTrackConnectionType.Multicast && !IsMulticastText( connectionTypeText ) ) {
+				warnings.Add( "Connection type was not recognized. Using Multicast." );
+			}
+
+			if ( !NatNetDependenciesPresent() ) {
+				warnings.Add( "NatNetML.dll or NatNetLib.dll is missing from the plugin output folder." );
+				valid = false;
+			}
+
+			if ( telemetryEnabled && telemetry.Status.StartsWith( "disabled", StringComparison.OrdinalIgnoreCase ) ) {
+				warnings.Add( "Telemetry was enabled, but Sentry is not configured. Set SENTRY_DSN or tracker.telemetry.local.json to activate it." );
+			}
+
+			return valid;
+		}
+
+		private void ReportNoFrameWarning() {
+			if ( currentFrame != null || connectionStartedUtc == DateTime.MinValue ) {
+				return;
+			}
+
+			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > 5 ) {
+				string warning = "Connected, but no NatNet frame has been received. Check Motive broadcasting, firewall, IP addresses, ports, and multicast/unicast settings.";
+				if ( !warnings.Contains( warning ) ) {
+					warnings.Add( warning );
+					AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );
+				}
+			}
+		}
+
+		private static bool IsValidPort( int port ) {
+			return port >= 1 && port <= 65535;
+		}
+
+		private static bool NatNetDependenciesPresent() {
+			string assemblyLocation = typeof( TrackerComponent ).Assembly.Location;
+			string baseDirectory = string.IsNullOrWhiteSpace( assemblyLocation ) ? AppDomain.CurrentDomain.BaseDirectory : Path.GetDirectoryName( assemblyLocation );
+			return File.Exists( Path.Combine( baseDirectory, "NatNetML.dll" ) ) && File.Exists( Path.Combine( baseDirectory, "NatNetLib.dll" ) );
+		}
+
+		private static OptiTrackConnectionType ParseConnectionType( string value ) {
+			if ( string.Equals( value, "Unicast", StringComparison.OrdinalIgnoreCase ) ) {
+				return OptiTrackConnectionType.Unicast;
+			}
+
+			return OptiTrackConnectionType.Multicast;
+		}
+
+		private static bool IsMulticastText( string value ) {
+			return string.Equals( value, "Multicast", StringComparison.OrdinalIgnoreCase );
 		}
 
 		protected override void AppendAdditionalComponentMenuItems( ToolStripDropDown menu ) {

--- a/src/Tracker/TrackerComponent.cs
+++ b/src/Tracker/TrackerComponent.cs
@@ -24,10 +24,10 @@ namespace Tracker {
 		private static OptiTrackFrame currentFrame;
 		private static DateTime connectionStartedUtc = DateTime.MinValue;
 		private static DateTime lastFrameUtc = DateTime.MinValue;
+		private static bool noFrameWarningReported;
 		private static bool handlersAttached;
 		private static bool connectionConfirmed;
 		private static bool telemetryEnabled;
-		private static int counter;
 
 		private static bool RigidBody;
 		private static bool Skeleton;
@@ -62,7 +62,7 @@ namespace Tracker {
 			pManager.AddTextParameter( "Connection Type", "Type", "NatNet connection type: Multicast or Unicast.", GH_ParamAccess.item, "Multicast" );
 			pManager.AddIntegerParameter( "Command Port", "Cmd Port", "NatNet server command port.", GH_ParamAccess.item, 1510 );
 			pManager.AddIntegerParameter( "Data Port", "Data Port", "NatNet server data port.", GH_ParamAccess.item, 1511 );
-			pManager.AddNumberParameter( "Scale Factor", "Scale", "Additional scale factor applied to rigid body planes.", GH_ParamAccess.item, 1.0 );
+			pManager.AddNumberParameter( "Scale Factor", "Scale", "Additional scale factor applied to marker points and rigid body planes.", GH_ParamAccess.item, 1.0 );
 			pManager.AddBooleanParameter( "Y Up", "Y Up", "Apply the existing Y-up coordinate adjustment.", GH_ParamAccess.item, false );
 			pManager.AddIntegerParameter( "Redraw Throttle", "Throttle", "Process every Nth NatNet frame. Use 1 for every frame.", GH_ParamAccess.item, 4 );
 			pManager.AddBooleanParameter( "Debug Logging", "Debug", "Show additional component runtime remarks.", GH_ParamAccess.item, false );
@@ -116,7 +116,9 @@ namespace Tracker {
 			DA.GetData( 11, ref enableTelemetry );
 
 			warnings.Clear();
-			yUp = yUpInput;
+			if ( Params.Input[ 8 ].SourceCount > 0 ) {
+				yUp = yUpInput;
+			}
 			ConfigureTelemetry( enableTelemetry );
 
 			OptiTrackConnectionType connectionType = ParseConnectionType( connectionTypeText );
@@ -135,17 +137,14 @@ namespace Tracker {
 			if ( reset ) {
 				ClearFrameState();
 				DisconnectClient();
-				counter = 0;
 				AddRuntimeMessage( GH_RuntimeMessageLevel.Remark, "Tracker client reset." );
 			}
 
-			if ( connect && counter == 0 ) {
-				ConnectClient( localIP, serverIP, connectionType, commandPort, dataPort, scaleFactor, redrawThrottle, debugLogging );
-				counter++;
+			if ( connect && !connectionConfirmed ) {
+				ConnectClient( localIP, serverIP, connectionType, commandPort, dataPort, redrawThrottle );
 			} else if ( connect && connectionConfirmed ) {
 				ProcessFrameData( currentFrame, scaleFactor );
 				ReportNoFrameWarning();
-				counter++;
 			} else if ( !connect ) {
 				DisconnectClient();
 				ClearFrameState();
@@ -157,7 +156,9 @@ namespace Tracker {
 			}
 
 			SetOutputs( DA );
-			ExpireSolution( true );
+			if ( connect ) {
+				ExpireSolution( true );
+			}
 		}
 
 		private void SetOutputs( IGH_DataAccess DA ) {
@@ -191,9 +192,16 @@ namespace Tracker {
 			}
 
 			telemetry = SentryTelemetryService.Create( enableTelemetry );
-			if ( !connectionConfirmed ) {
-				ResetClient();
+			bool wasConnected = connectionConfirmed || (optiTrackClient != null && optiTrackClient.IsConnected);
+			if ( wasConnected ) {
+				DisconnectClient();
+				Log.Add( "Telemetry setting changed. Reconnecting to apply updated telemetry." );
+				connectionStartedUtc = DateTime.UtcNow;
+				lastFrameUtc = DateTime.MinValue;
+				currentFrame = null;
 			}
+
+			ResetClient();
 		}
 
 		private static void ResetClient() {
@@ -206,7 +214,7 @@ namespace Tracker {
 			handlersAttached = false;
 		}
 
-		private static void ConnectClient( string localIP, string serverIP, OptiTrackConnectionType connectionType, int commandPort, int dataPort, double scaleFactor, int redrawThrottle, bool debugLogging ) {
+		private static void ConnectClient( string localIP, string serverIP, OptiTrackConnectionType connectionType, int commandPort, int dataPort, int redrawThrottle ) {
 			EnsureClientHandlers();
 			Log.Clear();
 			Log.Add( "NatNet managed client application starting..." );
@@ -215,6 +223,7 @@ namespace Tracker {
 			Log.Add( "Attempting connection to Motive NatNet server..." );
 			connectionStartedUtc = DateTime.UtcNow;
 			lastFrameUtc = DateTime.MinValue;
+			noFrameWarningReported = false;
 
 			OptiTrackConnectionOptions options = new OptiTrackConnectionOptions {
 				LocalAddress = localIP,
@@ -226,10 +235,7 @@ namespace Tracker {
 				IncludeRigidBodies = RigidBody,
 				IncludeSkeletons = Skeleton,
 				IncludeForcePlates = ForcePlate,
-				FrameDivisor = redrawThrottle,
-				ScaleFactor = scaleFactor,
-				YUp = yUp,
-				DebugLogging = debugLogging
+				FrameDivisor = redrawThrottle
 			};
 
 			try {
@@ -277,6 +283,7 @@ namespace Tracker {
 		private static void OnFrameReceived( object sender, OptiTrackFrameEventArgs e ) {
 			currentFrame = e.Frame;
 			lastFrameUtc = DateTime.UtcNow;
+			noFrameWarningReported = false;
 		}
 
 		private static void OnConnectionChanged( object sender, OptiTrackConnectionEventArgs e ) {
@@ -294,6 +301,7 @@ namespace Tracker {
 			rBodyPlanes.Clear();
 			rBodyTransforms.Clear();
 			warnings.Clear();
+			noFrameWarningReported = false;
 		}
 
 		private void ProcessFrameData( OptiTrackFrame frame, double scaleFactor ) {
@@ -419,15 +427,15 @@ namespace Tracker {
 
 		private void ReportNoFrameWarning() {
 			if ( currentFrame != null || connectionStartedUtc == DateTime.MinValue ) {
+				noFrameWarningReported = false;
 				return;
 			}
 
-			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > 5 ) {
+			if ( DateTime.UtcNow.Subtract( connectionStartedUtc ).TotalSeconds > 5 && !noFrameWarningReported ) {
 				string warning = "Connected, but no NatNet frame has been received. Check Motive broadcasting, firewall, IP addresses, ports, and multicast/unicast settings.";
-				if ( !warnings.Contains( warning ) ) {
-					warnings.Add( warning );
-					AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );
-				}
+				warnings.Add( warning );
+				AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, warning );
+				noFrameWarningReported = true;
 			}
 		}
 
@@ -437,7 +445,14 @@ namespace Tracker {
 
 		private static bool NatNetDependenciesPresent() {
 			string assemblyLocation = typeof( TrackerComponent ).Assembly.Location;
-			string baseDirectory = string.IsNullOrWhiteSpace( assemblyLocation ) ? AppDomain.CurrentDomain.BaseDirectory : Path.GetDirectoryName( assemblyLocation );
+			string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+			if ( !string.IsNullOrWhiteSpace( assemblyLocation ) ) {
+				string assemblyDirectory = Path.GetDirectoryName( assemblyLocation );
+				if ( !string.IsNullOrWhiteSpace( assemblyDirectory ) ) {
+					baseDirectory = assemblyDirectory;
+				}
+			}
+
 			return File.Exists( Path.Combine( baseDirectory, "NatNetML.dll" ) ) && File.Exists( Path.Combine( baseDirectory, "NatNetLib.dll" ) );
 		}
 


### PR DESCRIPTION
This pull request introduces Tracker v1.4.0, which expands the OptiTrack Stream Grasshopper component with new connection options, richer outputs, improved validation and error messaging, and optional Sentry-based telemetry. The documentation has been updated throughout to reflect these enhancements, and several new configuration and troubleshooting details are included. The default behavior remains backwards compatible, with telemetry strictly opt-in and disabled unless explicitly enabled and configured.

**OptiTrack Stream Component Enhancements:**

* Expanded component inputs to support connection type (multicast/unicast), NatNet command/data ports, scale factor, Y-up transform, redraw throttle, debug logging, and optional telemetry enablement. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-fdb738f780c8daca013caeef76ce43b4c0a171cc8d08c0d92256c67d1e43e4ebR1-R49)
* Added new outputs for rigid body transforms, frame number, timestamp, latency, warnings, and telemetry status, while preserving original output order for compatibility. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-fdb738f780c8daca013caeef76ce43b4c0a171cc8d08c0d92256c67d1e43e4ebR1-R49)
* Updated `OptiTrackConnectionOptions` and `OptiTrackConnectionInfo` models to include command/data ports, scale factor, Y-up, and debug logging. [[1]](diffhunk://#diff-edf53a9386b9ce000fbdd3383e4b0383aa8b30306e0232a4d45b84af8f0e2c73R16-R19) [[2]](diffhunk://#diff-edf53a9386b9ce000fbdd3383e4b0383aa8b30306e0232a4d45b84af8f0e2c73R29-R34) [[3]](diffhunk://#diff-d56a5c2285ee1b511a951c7d17e26f026582341236b39d53791db9a77cf9ca87R19-R22)
* `OptiTrackFrame` now includes timestamp and latency fields.
* NatNet connection and frame conversion logic updated to support new options and outputs. [[1]](diffhunk://#diff-d7d716926e2ca0af844faa93984a30bd0314bc3b83d18b82810884bcedc6b80bL12-R12) [[2]](diffhunk://#diff-d7d716926e2ca0af844faa93984a30bd0314bc3b83d18b82810884bcedc6b80bR57-R58) [[3]](diffhunk://#diff-2345b3c6bdd1aa42f1b114999de5c9d0757d98f674821df9c72f92e72966dd7eL78-R80)

**Telemetry and Sentry Integration:**

* Added optional Sentry error reporting through `ITelemetryService` and `SentryTelemetryService`, disabled by default and only active when explicitly enabled and configured. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L23-R23) [[3]](diffhunk://#diff-8e9c1354875e7b4eaf5b4056ea10b1a7aaa24176656ecbf9fe259dc4d1dadc1aL35-R35) [[4]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L3-R3) [[5]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L15-R15) [[6]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L25-R41) [[7]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L39-R52) [[8]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L84-R97)
* Sentry configuration supports environment variables and a local `tracker.telemetry.local.json` file, with sanitized reporting and strict data boundaries. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R65) [[3]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L25-R41) [[4]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L39-R52)
* Documentation updated to clarify opt-in telemetry, configuration, and privacy policies. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R78) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L23-R23) [[4]](diffhunk://#diff-8e9c1354875e7b4eaf5b4056ea10b1a7aaa24176656ecbf9fe259dc4d1dadc1aL35-R35) [[5]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L3-R3) [[6]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L15-R15) [[7]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L25-R41) [[8]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L39-R52) [[9]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L84-R97)

**Documentation and Troubleshooting:**

* Added and updated guides for setup, new component features, telemetry configuration, and troubleshooting, including example usage and error scenarios. [[1]](diffhunk://#diff-fdb738f780c8daca013caeef76ce43b4c0a171cc8d08c0d92256c67d1e43e4ebR1-R49) [[2]](diffhunk://#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23L40-R56) [[3]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dR24-R36) [[4]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dL45-R55) [[5]](diffhunk://#diff-a2f98cb762a85ea01bf5613f079da51613ce8cfbb408d30df24fb3e36074d5d1R1-R18)
* Updated compatibility documentation to reflect Sentry SDK version and clarify default-disabled behavior.

**Versioning and Changelog:**

* Bumped version to v1.4.0 with a detailed changelog summarizing all major changes and new features. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R78)

**Key references:** [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R11) [[2]](diffhunk://#diff-fdb738f780c8daca013caeef76ce43b4c0a171cc8d08c0d92256c67d1e43e4ebR1-R49) [[3]](diffhunk://#diff-edf53a9386b9ce000fbdd3383e4b0383aa8b30306e0232a4d45b84af8f0e2c73R16-R19) [[4]](diffhunk://#diff-edf53a9386b9ce000fbdd3383e4b0383aa8b30306e0232a4d45b84af8f0e2c73R29-R34) [[5]](diffhunk://#diff-d56a5c2285ee1b511a951c7d17e26f026582341236b39d53791db9a77cf9ca87R19-R22) [[6]](diffhunk://#diff-96304cc3c512028b50f8a2316d0ac7f70b5afea5fb2f99f83b38a46dcfc609faR59-R62) [[7]](diffhunk://#diff-d7d716926e2ca0af844faa93984a30bd0314bc3b83d18b82810884bcedc6b80bL12-R12) [[8]](diffhunk://#diff-d7d716926e2ca0af844faa93984a30bd0314bc3b83d18b82810884bcedc6b80bR57-R58) [[9]](diffhunk://#diff-2345b3c6bdd1aa42f1b114999de5c9d0757d98f674821df9c72f92e72966dd7eL78-R80) [[10]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L23-R23) [[11]](diffhunk://#diff-8e9c1354875e7b4eaf5b4056ea10b1a7aaa24176656ecbf9fe259dc4d1dadc1aL35-R35) [[12]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L3-R3) [[13]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L15-R15) [[14]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L25-R41) [[15]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L39-R52) [[16]](diffhunk://#diff-fd2f3e43dd11fcf5b5bcbc41f845b63466fb47b1ecfc593c8d098428e6762857L84-R97) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R65) [[18]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R78) [[19]](diffhunk://#diff-16cdac13dd8a32decd591a6b2ab41b65468dc12835e78ee1bceb4e6b7fbcf315L13-R19) [[20]](diffhunk://#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23L40-R56) [[21]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dR24-R36) [[22]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dL45-R55) [[23]](diffhunk://#diff-a2f98cb762a85ea01bf5613f079da51613ce8cfbb408d30df24fb3e36074d5d1R1-R18)